### PR TITLE
fix(playback): DisablePauseWithLive should now work properly

### DIFF
--- a/src/js/Html5Player.js
+++ b/src/js/Html5Player.js
@@ -290,7 +290,7 @@ class Html5Player extends Meister.PlayerPlugin {
     }
 
     isPauseDisabled() {
-        return (this.isLive && this.meister.config.disablePauseWithLive);
+        return !!this.isLive && !!this.meister.config.disablePauseWithLive;
     }
 
     get duration() {


### PR DESCRIPTION
The issue was that (<expression> && <other_expression>) does not
guarantee a boolean result. For example: `undefined && true` will
evaluate to `undefined` just as `true && undefined`.

Closes meisterplayer/meisterplayer#30