### PR TITLE
fix(events): No longer fire firstPlay event on ad resume

### DIFF
--- a/src/js/Html5Player.js
+++ b/src/js/Html5Player.js
@@ -95,7 +95,12 @@ class Html5Player extends Meister.PlayerPlugin {
 
         this.wrapper.appendChild(this.mediaElement);
 
-        this.meister.on('playerPlay', () => {
+        this.meister.on('playerPlay', (e) => {
+            // Advertisements don't count as actual playback
+            if (e && e.type === 'ad') {
+                return;
+            }
+
             // Replays are when an end event has been triggered and the user clicks on play again.
             if (this.shouldTriggerReplay) {
                 // Make sure that the replay event is only triggered when the src is the same as the current item.


### PR DESCRIPTION
Previosuly resuming a paused preroll would incorrectly trigger the
playerFirstPlay event. This can be prevented by checking whether the
event originated from an ad or not.